### PR TITLE
version adjustion of rasterio

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pandas =0.23.4
   - pillow =5.3.0
   - pyyaml =3.13
-  - rasterio =1.0.9
+  - rasterio =1.0.13
   - shapely =1.6.4
   - s3fs =0.1.6
   - tornado =5.1


### PR DESCRIPTION
adjusted version of rasterio, because the existing version was not recognized by travis ci and therefore the environment could not be built.