### PR TITLE
Force ISO time stamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
+  - conda config --add channels conda-forge
+  - conda config --set channel_priority strict
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # Useful for debugging any issues with conda

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,26 @@ import shapely.geometry
 import xarray as xr
 
 from xcube_server.im import TileGrid
-from xcube_server.utils import compute_tile_grid, get_dataset_geometry, get_dataset_bounds, get_geometry_mask
+from xcube_server.utils import compute_tile_grid, get_dataset_geometry, get_dataset_bounds, get_geometry_mask, \
+    timestamp_to_iso_string
+
+
+class TimestampToIsoStringTest(unittest.TestCase):
+    def test_it_with_default_res(self):
+        self.assertEqual("2018-09-05T00:00:00Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05")))
+        self.assertEqual("2018-09-05T10:35:42Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42")))
+        self.assertEqual("2018-09-05T10:35:42Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42.164")))
+
+    def test_it_with_h_res(self):
+        self.assertEqual("2018-09-05T00:00:00Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05"), freq="H"))
+        self.assertEqual("2018-09-05T11:00:00Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42"), freq="H"))
+        self.assertEqual("2018-09-05T11:00:00Z",
+                         timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42.164"), freq="H"))
 
 
 class GetDatasetGeometryTest(unittest.TestCase):

--- a/xcube_server/controllers/catalogue.py
+++ b/xcube_server/controllers/catalogue.py
@@ -7,7 +7,7 @@ from ..context import ServiceContext
 from ..controllers.tiles import get_tile_source_options, get_dataset_tile_url, get_or_compute_tile_grid
 from ..errors import ServiceBadRequestError
 from ..im.cmaps import get_cmaps
-from ..utils import get_dataset_bounds
+from ..utils import get_dataset_bounds, timestamp_to_iso_string
 
 
 def get_datasets(ctx: ServiceContext, details=False, client=None, base_url: str = None) -> Dict:
@@ -102,7 +102,7 @@ def get_dataset_coordinates(ctx: ServiceContext, ds_id: str, dim_name: str) -> D
     elif np.issubdtype(var.dtype, np.integer):
         converter = int
     else:
-        converter = str
+        converter = timestamp_to_iso_string
     for value in var.values:
         values.append(converter(value))
     return dict(name=dim_name,
@@ -135,7 +135,7 @@ def get_color_bars(ctx: ServiceContext, mime_type: str) -> str:
                 cmap_name, cmap_data = cmap_bar
                 cmap_image = f'<img src="data:image/png;base64,{cmap_data}" width="100%%" height="32"/>'
                 html_body += f'        <tr><td style="width: 5em">{cmap_name}:' \
-                             f'</td><td style="width: 40em">{cmap_image}</td></tr>\n'
+                    f'</td><td style="width: 40em">{cmap_image}</td></tr>\n'
             html_body += '    </table>\n'
         return html_head + html_body + html_foot
     raise ServiceBadRequestError(f'Format {mime_type!r} not supported for color bars')

--- a/xcube_server/handlers.py
+++ b/xcube_server/handlers.py
@@ -137,7 +137,7 @@ class GetDatasetsHandler(ServiceRequestHandler):
         tile_client = self.params.get_query_argument('tiles', None)
         response = get_datasets(self.service_context, details=details, client=tile_client, base_url=self.base_url)
         self.set_header('Content-Type', 'application/json')
-        self.write(json.dumps(response, indent=2))
+        self.write(json.dumps(response, indent=None if details else 2))
 
 
 class GetDatasetHandler(ServiceRequestHandler):

--- a/xcube_server/utils.py
+++ b/xcube_server/utils.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple, Union, Dict, Any, List
 
 import affine
 import numpy as np
+import pandas as pd
 import rasterio.features
 import shapely.geometry
 import shapely.geometry
@@ -109,6 +110,20 @@ def get_geometry_mask(width: int, height: int,
                                            transform=transform,
                                            all_touched=True,
                                            invert=True)
+
+
+def timestamp_to_iso_string(time: np.datetime64, freq='S'):
+    """
+    Convert a UTC timestamp given as nanos, millis, seconds, etc. since 1970-01-01 00:00:00
+    to an ISO-format string.
+
+    :param time: UTC timestamp given as time delta since since 1970-01-01 00:00:00 in the units given by
+           the numpy datetime64 type, so it can be as nanos, millis, seconds since 1970-01-01 00:00:00.
+    :param freq: time rounding resolution. See pandas.Timestamp.round().
+    :return: ISO-format string.
+    """
+    # All times are UTC (Z = Zulu Time Zone = UTC)
+    return pd.Timestamp(time).round(freq).isoformat() + 'Z'
 
 
 class GeoJSON:


### PR DESCRIPTION
When you accept this, then the new utility function `timestamp_to_iso_string()` is used whenever  timestamps are returned by API.
