### PR TITLE
Dzelge docker init

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git/
+
+build
+dist
+*.egg-info
+*.egg/
+*.pyc
+*.swp
+
+.tox
+.coverage
+html/*
+__pycache__
+
+# Compiled Documentation
+docs/_build

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## Changes in 0.1.0.dev5
 
 * Request for obtaining a legend for a layer of given by a variable of a data set was added.
-* Added a Dockerfile 
+* Added a Dockerfile to build an xcube docker image and to run the demo
 
 ## Changes in 0.1.0.dev4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Changes in 0.1.0.dev5
 
-* Request for obtaining a legend for a layer of given by a variable of a data set was added. 
+* Request for obtaining a legend for a layer of given by a variable of a data set was added.
+* Added a Dockerfile 
 
 ## Changes in 0.1.0.dev4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3:latest
 MAINTAINER helge.dzierzon@brockmann-consult.de
 
 LABEL name=xcube-server
-LABEL version=0.1.0.dev5
+LABEL version=0.1.0.dev6
 LABEL conda_env=xcube-server-dev
 
 # Ensure usage of bash (simplifies source activate calls)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3:latest
 MAINTAINER helge.dzierzon@brockmann-consult.de
 
 LABEL name=xcube-server
-LABEL version=0.1.0
+LABEL version=0.1.0.dev5
 LABEL conda_env=xcube-server-dev
 
 # Ensure usage of bash (simplifies source activate calls)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Image from https://hub.docker.com (syntax: repo/image:version)
+FROM continuumio/miniconda3:latest
+
+# Person responsible
+MAINTAINER helge.dzierzon@brockmann-consult.de
+
+LABEL name=xcube-server
+LABEL version=0.1.0
+LABEL conda_env=xcube-server-dev
+
+# Ensure usage of bash (simplifies source activate calls)
+SHELL ["/bin/bash", "-c"]
+
+# Update system and install dependencies
+RUN apt-get -y update && apt-get -y upgrade
+
+# && apt-get -y install  git build-essential libyaml-cpp-dev
+
+# Setup conda environment
+# Copy yml config into image
+ADD environment.yml /tmp/environment.yml
+
+# Update conda and install dependecies specified in environment.yml
+RUN  conda env create -f=/tmp/environment.yml;
+
+# Set work directory for xcube server installation
+RUN mkdir /xcube-server
+WORKDIR /xcube-server
+
+# Copy local github repo into image (will be replaced by either git clone or as a conda dep)
+ADD . /xcube-server
+
+# Setup eocdb-dev
+RUN source activate xcube-server-dev && python setup.py develop
+
+# Test eocdb-dev
+ENV NUMBA_DISABLE_JIT 1
+  # Uncomment following line if web testing on travis breaks our build
+ENV CATE_DISABLE_WEB_TESTS 1
+ENV CATE_DISABLE_PLOT_TESTS 1
+ENV CATE_DISABLE_CLI_UPDATE_TESTS 1
+RUN source activate xcube-server-dev && pytest
+
+# Export web server port 4000
+EXPOSE 8000
+
+# Start server
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["source activate xcube-server-dev && xcube-server -v -c xcube_server/res/demo/config.yml -p 8000 -a '0.0.0.0' -u 30 "]

--- a/README.md
+++ b/README.md
@@ -128,7 +128,13 @@ you can run the client demos by following their links given below.
 To start a demo using docker use the following commands
 
     $ docker build -t [your name] .
-    $ docker run -p [host port]:8000 [your name] 
+    $ docker run -d -p [host port]:8000 [your name]
+    
+**Example:**
+
+    $  docker build -t xcube:0.1.0dev6 .
+    $  docker run -d -p 8001:8000 xcube:0.1.0dev6
+    $  docker ps
 
 **TODO:** 
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ After starting both the xcube-server and web server, e.g. on port 9090
 
 you can run the client demos by following their links given below.
     
+    
+### Docker
+
+To start a demo using docker use the following commands
+
+    $ docker build -t [your name] .
+    $ docker run -p [host port]:8000 [your name] 
+
+**TODO:** 
+
+The idea is to have the container automatically build on quay.io 
+and then used in a xcube-services ```docker-compose.yml``` configuration.
+
 
 #### OpenLayers
 


### PR DESCRIPTION
When accepting this PR a Dockerilfe will be added taht can be used to build an xcube-server image.
The image can then be used to run the demo. The image can also be used in an deployment infrastructure
(e.g. by having quay.io build this image)